### PR TITLE
feat: Introduce Unix process signal capturing from the ECS Service Scheduler

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"log"
 	"os"
-	"slices"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -13,19 +14,25 @@ import (
 	"github.com/chriswachira/aws-cloud-map-custom-health-checker/services"
 )
 
-// List of task lifecycle states that a task transitions to from RUNNING.
-var ecsTaskShutdownStates = []string{
-	"DEACTIVATING",
-	"DEPROVISIONING",
-	"STOPPING",
-}
+const (
+	exitCodeSuccess      = 0
+	exitCodeProgramError = 1
+)
 
 func main() {
 
+	// A task can be healthy and ACTIVATING status at the same time, meaning that if
+	// this app container, that is configured as a dependency for an essential container,
+	// is launched after the essential becomes HEALTHY, this app will deregister the
+	// task from its Cloud Map service before it transitions to the RUNNING state.
 	log.Println("Waiting for task to fully initialize; sleeping for 60 seconds...")
 	time.Sleep(time.Duration(time.Second * 60))
 
+	// Initialize a channel that we can use to capture process signals from
+	// the ECS Service Scheduler.
 	log.Println("Initializing AWS Cloud Map Custom Health Checker for Amazon ECS...")
+	signalChannel := make(chan os.Signal, 2)
+	signal.Notify(signalChannel, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 
 	// Fetch the V4 Metadata URI from the injected environment variable.
 	// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4-fargate.html
@@ -44,14 +51,13 @@ func main() {
 	ecsClient := ecs.NewFromConfig(cfg)
 	serviceDiscoveryClient := servicediscovery.NewFromConfig(cfg)
 
-	// Fetch task metadata from the V4 Metadata Endpoint - here we get the task ARN
+	// Get task information from V4 endpoint and ECS API
 	taskMetadataFromEndpoint := services.GetTaskV4Metadata(ecsContainerMetadataV4Endpoint)
-
-	// Fetch task information from the ECS API using the task ARN - here we want to get the task's service.
-	taskInfoFromApi := services.DescribeTask(*ecsClient, taskMetadataFromEndpoint)
+	// taskDefinitionDetails := services.GetTaskDefinitionDetails(*ecsClient, taskMetadataFromEndpoint.Family, taskMetadataFromEndpoint.Revision)
+	taskInfoFromEcsApi := services.DescribeTask(*ecsClient, taskMetadataFromEndpoint)
 
 	// Get the task's service name from the "group" parameter
-	serviceName := services.GetECSServiceForTask(taskInfoFromApi)
+	serviceName := services.GetECSServiceForTask(taskInfoFromEcsApi)
 
 	// Fetch the service's service connect resources. We're interested in the Cloud Map Service ID (from DiscoveryArn)
 	svcConnectResponse, enabled := services.GetServiceConnectResources(ecsClient, taskMetadataFromEndpoint.Cluster, serviceName)
@@ -60,41 +66,29 @@ func main() {
 	if enabled {
 		log.Printf("Discovery ARN for service %s - %s", serviceName, *svcConnectResponse.DiscoveryArn)
 		log.Printf("Discovery name for service %s - %s", serviceName, *svcConnectResponse.DiscoveryName)
+		log.Printf("Listening for an interrupt signal from the ECS Service Scheduler...")
 
-		for {
+		// Capture a process signal from the main go-routine. Here we want to capture the
+		// SIGTERM signal that is sent from the ECS Service Scheduler when a user stops the task or
+		// when the task becomes unhealthy. The SIGINT signal is mostly for local development.
+		// We obviously can't catch the SIGKILL signal so it's not included in the signal capture below.
+		sig := <-signalChannel
+		switch sig {
+		case syscall.SIGTERM, syscall.SIGINT:
+			log.Println("Received an interrupt signal from the ECS Service Scheduler...")
+			log.Printf("Attempting to de-register task's Cloud Map instance from the %s discovery name...", *svcConnectResponse.DiscoveryName)
 
-			// Here, we want to check the status of the task periodically after 5 seconds
-			time.Sleep(time.Duration(time.Second * 5))
+			taskId := services.GetResourcePhysicalIdFromArn(*taskInfoFromEcsApi.TaskArn)
+			cloudMapServiceId := services.GetResourcePhysicalIdFromArn(*svcConnectResponse.DiscoveryArn)
 
-			// Fetch the task's health status from the ECS API
-			taskInfoFromEcsApi := services.DescribeTask(*ecsClient, taskMetadataFromEndpoint)
-			healthStatus := services.GetTaskHealthStatus(taskInfoFromEcsApi)
-			lastKnownStatus := services.GetTaskLastKnownStatus(taskInfoFromEcsApi)
+			deregistered := services.DeregisterTaskFromCloudMapService(*serviceDiscoveryClient, taskId, cloudMapServiceId)
+			if deregistered {
 
-			log.Printf("Task %s status is %s and %s", *taskInfoFromApi.TaskArn, healthStatus, lastKnownStatus)
-
-			// If the task's status is anything other than HEALTHY or the lifecycle state is not RUNNING and is either DEPROVISIONING,
-			// DEPROVISIONING or STOPPING, we'd rather have the task de-registered from Cloud Map
-			// than risk failed requests to the essential task since Cloud Map will route traffic regardless
-			// of the instance's (task's) health status, if no health check is configured.
-			// https://docs.aws.amazon.com/cloud-map/latest/dg/services-health-checks.html
-
-			if healthStatus != "HEALTHY" || slices.Contains(ecsTaskShutdownStates, lastKnownStatus) {
-
-				log.Printf("Attempting to de-register task's Cloud Map instance from the %s discovery name...", *svcConnectResponse.DiscoveryName)
-
-				taskId := services.GetResourcePhysicalIdFromArn(*taskInfoFromEcsApi.TaskArn)
-				cloudMapServiceId := services.GetResourcePhysicalIdFromArn(*svcConnectResponse.DiscoveryArn)
-
-				deregistered := services.DeregisterTaskFromCloudMapService(*serviceDiscoveryClient, taskId, cloudMapServiceId)
-				if deregistered {
-					break
-				}
+				// If we get here, our task was de-registered from Cloud Map,
+				// which means the task will be transitioning to STOPPED any time now.
+				log.Println("I have done my job. Goodbye!")
+				os.Exit(exitCodeSuccess)
 			}
 		}
-
-		// If we get here, our task was de-registered from Cloud Map,
-		// which means the task will be transitioning to STOPPED any time now.
-		log.Println("I have done my job. Goodbye!")
 	}
 }


### PR DESCRIPTION
This work introduces capturing the `SIGTERM` Unix process signal that is sent from the ECS Service Scheduler in order to deregister the task from the configured Cloud Map service.

Using process signal capturing avoids using the `DescribeTasks` API which can lead to API throttling. To avoid duplication, this PR also omits the logic of checking a task's health status since Amazon ECS will perform health checks and stop the task (send a `SIGTERM` signal) if it's unhealthy.